### PR TITLE
Don't use postinstall for rust installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "now-postinstall": "node dist/install-rust.js",
     "prepublishOnly": "tsc",
     "test": "tsc && jest",
     "typecheck": "tsc --noEmit"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 	DownloadedFiles,
 	Lambda
 } from "@now/build-utils"; // eslint-disable-line import/no-extraneous-dependencies
+import { installRustAndFriends } from './install-rust';
 
 interface PackageManifest {
 	targets: { kind: string; name: string }[];
@@ -269,6 +270,8 @@ async function buildSingleFile(
 }
 
 export async function build(opts: BuildOptions) {
+	await installRustAndFriends();
+
 	const { files, entrypoint, workPath, config, meta = {} } = opts;
 	console.log("downloading files");
 	const downloadedFiles = await download(files, workPath, meta);

--- a/src/install-rust.ts
+++ b/src/install-rust.ts
@@ -39,7 +39,3 @@ export const installRustAndFriends = async (version?: string) => {
 	await installOpenSSL();
 };
 
-installRustAndFriends().catch(err => {
-	console.error(err);
-	process.exit(1);
-});


### PR DESCRIPTION
It makes debugging rustup or openssl errors impossible.

Fixes #10