### PR TITLE
Don't attempt downgrading krb5 anymore

### DIFF
--- a/src/install-rust.ts
+++ b/src/install-rust.ts
@@ -16,15 +16,6 @@ async function downloadRustToolchain(version: string = "stable") {
 async function installOpenSSL() {
 	console.log("installing openssl-devel...");
 	try {
-		// need to downgrade otherwise yum can't resolve the dependencies given
-		// a later version is already installed in the machine.
-		await execa(
-			"yum",
-			["downgrade", "-y", "krb5-libs-1.14.1-27.41.amzn1.x86_64"],
-			{
-				stdio: "inherit"
-			}
-		);
 		await execa("yum", ["install", "-y", "openssl-devel"], {
 			stdio: "inherit"
 		});


### PR DESCRIPTION
It fails with `No package available` error on current lambda env,
and seems to no longer be necessary, my lambdas work fine with the
omission.

Build errors before this change:

```
Installing build runtime...
Build runtime installed: 2672.076ms
Looking up build cache...
downloading files
downloading the rust toolchain
what
warning: $HOME differs from euid-obtained home directory: you may be using sudo
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2019-09-26, rust version 1.38.0 (625451e37 2019-09-23)
info: downloading component 'rustc'
info: downloading component 'rust-std'
info: downloading component 'cargo'
info: downloading component 'rust-docs'
info: installing component 'rustc'
info: installing component 'rust-std'
info: installing component 'cargo'
info: installing component 'rust-docs'
info: default toolchain set to 'stable'

  stable installed - rustc 1.38.0 (625451e37 2019-09-23)


Rust is installed now. Great!

To get started you need Cargo's bin directory ($HOME/.cargo/bin) in your PATH 
environment variable. Next time you log in this will be done automatically.

To configure your current shell run source $HOME/.cargo/env
installing openssl-devel...
No package krb5-libs-1.14.1-27.41.amzn1.x86_64 available.
Error: Nothing to do
failed to `yum install -y openssl-devel`
{ Error: Command failed: yum downgrade -y krb5-libs-1.14.1-27.41.amzn1.x86_64
    at makeError (/tmp/0e9a2a218d6b4dc7/.build-utils/.builder/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/tmp/0e9a2a218d6b4dc7/.build-utils/.builder/node_modules/execa/index.js:278:16)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
  code: 1,
  stdout: null,
  stderr: null,
  failed: true,
  signal: null,
  cmd: 'yum downgrade -y krb5-libs-1.14.1-27.41.amzn1.x86_64',
  timedOut: false,
  killed: false }
worker exited with code 20 and signal null
done
```