### PR TITLE
Add support for .exe extension in Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,19 +170,27 @@ async function buildSingleFile(
 		);
 	}
 
+	// The compiled binary in Windows has the `.exe` extension
+	const binExtension = (process.platform === "win32") ? '.exe' : "";
+
 	const bin = path.join(
 		path.dirname(cargoTomlFile),
 		"target",
 		builderDebug ? "debug" : "release",
-		binName
+		binName + binExtension
 	);
 
+	debug("Binary file is: " + bin);
+	console.log("Binary file is: " + bin);
+
+	const bootstrap = "bootstrap" + binExtension;
+	
 	const lambda = await createLambda({
 		files: {
 			...extraFiles,
-			bootstrap: new FileFsRef({ mode: 0o755, fsPath: bin })
+			[bootstrap]: new FileFsRef({ mode: 0o755, fsPath: bin })
 		},
-		handler: "bootstrap",
+		handler: bootstrap,
 		runtime: "provided"
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,6 @@ async function buildSingleFile(
 	);
 
 	debug("Binary file is: " + bin);
-	console.log("Binary file is: " + bin);
 
 	const bootstrap = "bootstrap" + binExtension;
 	


### PR DESCRIPTION
There is no way I know in Windows to execute binaries without an extension; Rust adds this extension automatically when building, so at the end the binary file is not found (since it lacks extension).

I added the code so that when the platform is Windows (`win32`) the extension is taken into consideration

