### PR TITLE
fix: Destroy stdout and stderr on child vercel process

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,8 @@ async function testFixture(fixture) {
   const baseUrl = await isReady(vercelProcess);
   await checkProbes(baseUrl, vercelConf.probes);
   vercelProcess.cancel();
+  vercelProcess.stdout.destroy();
+  vercelProcess.stderr.destroy();
 }
 
 describe('vercel-rust', () => {


### PR DESCRIPTION
Regarding #48, I managed to get the tests running using node 15+, perhaps not ideal, but it worked.

However, jest could not exit the tests because of leaky handlers, this PR takes care of that.

After running the tests, a bunch of `.gitignore` and `vercel.json` files are created inside `tests/fixtures`, is that expected? 