### PR TITLE
doc: pin version of vercel-rust in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, you'll need a `vercel.json` file in your project:
 {
   "functions": {
     "api/**/*.rs": {
-      "runtime": "vercel-rust@latest"
+      "runtime": "vercel-rust@3.1.2"
     }
   }
 }


### PR DESCRIPTION
Hey folks,

With Vercel CLI 23.1.2, if I'm using the `latest` tag, I get the following error:

```sh
Vercel CLI 23.1.2 dev (beta) — https://vercel.com/feedback
Error! Function Runtimes must have a valid version, for example `now-php@1.0.0`.
```

Pinning the version resolves the issue.