### PR TITLE
Execute `cargo build` inside `workPath`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
         BUILDER_DEBUG ? ['--verbose'] : ['--quiet', '--release'],
       ),
       {
-        cwd: process.cwd(),
+        cwd: workPath,
         env: rustEnv,
         stdio: 'inherit',
       },


### PR DESCRIPTION
In attempting to get the [rspc workspace](https://github.com/oscartbeaumont/rspc) deployed on Vercel, we found that the execution of `cargo build` was not respecting the Root Directory that was configured for the project, but instead the root of the repository. Changing the working directory of that command to `workPath` seemed to solve the issue.

I wouldn't be surprised if this is a naive fix and other things need to be changed, but it worked for us!