### PR TITLE
use `vercel-dev-builder` for running tests

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "keywords": [],
-  "license": "ISC",
+  "license": "MIT",
   "author": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "rimraf dist/ && tsc --removeComments",
     "prepare": "husky install",
     "prepublishOnly": "tsc",
-    "test": "jest",
+    "test": "pnpm run build && jest",
     "typecheck": "tsc --noEmit"
   },
   "prettier": "@vercel/style-guide/prettier",

--- a/test/fixtures/01-include-files/package.json
+++ b/test/fixtures/01-include-files/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vercel-rust-demo",
+  "name": "01-include-files",
   "version": "1.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",
   "author": "",
-  "main": "index.js",
+  "main": "../../../dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/test/fixtures/01-include-files/vercel.json
+++ b/test/fixtures/01-include-files/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.rs": {
-      "runtime": "vercel-rust@4.0.0-beta.2",
+      "runtime": "vercel-dev-builder@0.0.5",
       "includeFiles": "static/**/*.{txt,svg}"
     }
   }

--- a/test/fixtures/02-with-utility/package.json
+++ b/test/fixtures/02-with-utility/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vercel-rust-demo",
+  "name": "02-with-utility",
   "version": "1.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",
   "author": "",
-  "main": "index.js",
+  "main": "../../../dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/test/fixtures/03-with-function/package.json
+++ b/test/fixtures/03-with-function/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vercel-rust-demo",
+  "name": "03-with-function",
   "version": "1.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",
   "author": "",
-  "main": "index.js",
+  "main": "../../../dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/test/fixtures/03-with-function/vercel.json
+++ b/test/fixtures/03-with-function/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.rs": {
-      "runtime": "vercel-rust@4.0.0-beta.2"
+      "runtime": "vercel-dev-builder@0.0.5"
     }
   }
 }

--- a/test/fixtures/04-with-parameter/package.json
+++ b/test/fixtures/04-with-parameter/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vercel-rust-demo",
+  "name": "04-with-parameter",
   "version": "1.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",
   "author": "",
-  "main": "index.js",
+  "main": "../../../dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/test/fixtures/04-with-parameter/vercel.json
+++ b/test/fixtures/04-with-parameter/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.rs": {
-      "runtime": "vercel-rust@4.0.0-beta.2"
+      "runtime": "vercel-dev-builder@0.0.5"
     }
   }
 }

--- a/test/fixtures/05-with-similar-entrypaths/package.json
+++ b/test/fixtures/05-with-similar-entrypaths/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "vercel-rust-demo",
+  "name": "05-with-similar-entrypaths",
   "version": "1.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",
   "author": "",
-  "main": "index.js",
+  "main": "../../../dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/test/fixtures/05-with-similar-entrypaths/vercel.json
+++ b/test/fixtures/05-with-similar-entrypaths/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.rs": {
-      "runtime": "vercel-rust@4.0.0-beta.2"
+      "runtime": "vercel-dev-builder@0.0.5"
     }
   }
 }


### PR DESCRIPTION
This PR allows to run integration tests without publishing to the registry.