### PR TITLE
vercel-rust: set `cargo metadata` to run in `workPath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-rust",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Rust runtime for Vercel Functions.",
   "homepage": "https://github.com/vercel-community/rust",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ async function buildHandler(
   debug(`Building \`${binaryName}\` for \`${process.platform}\` completed`);
 
   let { target_directory: targetDirectory } = await getCargoMetadata({
-    cwd: process.cwd(),
+    cwd: workPath,
     env: rustEnv,
   });
 


### PR DESCRIPTION
Should fix issue #110. I confirmed this works by forking the project: https://www.npmjs.com/package/@withpluto/vercel-rust