### PR TITLE
fix: select binary correctly while `vercel dev`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,11 @@ async function buildHandler(
 
   targetDirectory = path.join(targetDirectory, buildTarget);
 
+  const buildVariant = (BUILDER_DEBUG || meta?.isDev) ? 'debug' : 'release'
+
   const bin = path.join(
     targetDirectory,
-    BUILDER_DEBUG ? 'debug' : 'release',
+    buildVariant,
     getExecutableName(binaryName),
   );
 


### PR DESCRIPTION
Closes: #176

In previous #168, I added the ability to use debug to build rust binaries when vercel dev, but didn't change the code that selects the binary, resulting in the binary always not being found when `vercel dev`, and therefore vercel dev doesn't work.

@dglsparsons @ecklf please review and create a new release for this.