### PR TITLE
Fix bundled_api routing issue (similar to #144)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,8 +123,11 @@ async function buildHandler(
     debug(
       `experimental \`route-bundling\` detected - generating single entrypoint`,
     );
-    const handlerFiles = await glob('api/**/[!main]*.rs', workPath);
-    const routes = generateRoutes(Object.keys(handlerFiles));
+    const handlerFiles = await glob('api/**/*.rs', workPath);
+    const handlerKeysWithoutMain = Object.keys(handlerFiles).filter(
+      (filename) => !filename.endsWith("/main.rs")
+    );
+    const routes = generateRoutes(handlerKeysWithoutMain);
 
     return {
       output: routes.reduce<Record<string, Lambda>>((acc, route) => {


### PR DESCRIPTION
Thank you for maintaining this great project. 

We encountered an issue similar to #144 during our development. Although it was addressed in #145, we noticed that a related problem still remains in the following part of `index.ts`:

https://github.com/vercel-community/rust/blob/3540987a205d070e46365262da5b77d6fabd73a5/src/index.ts#L126-L127

This PR aims to resolve this issue. 